### PR TITLE
unsupported insn for bswap emitted

### DIFF
--- a/gcc/config/rs6000/rs6000.md
+++ b/gcc/config/rs6000/rs6000.md
@@ -2412,7 +2412,7 @@
   [(set (match_operand:SI 0 "reg_or_mem_operand" "")
 	(bswap:SI
 	 (match_operand:SI 1 "reg_or_mem_operand" "")))]
-  ""
+  "rs6000_cpu != PROCESSOR_PPE42"
 {
   if (!REG_P (operands[0]) && !REG_P (operands[1]))
     operands[1] = force_reg (SImode, operands[1]);

--- a/gcc/cp/cfns.gperf
+++ b/gcc/cp/cfns.gperf
@@ -21,7 +21,7 @@ __inline
 #endif
 static unsigned int hash (const char *, unsigned int);
 #ifdef __GNUC__
-//__inline
+__inline
 #endif
 const char * libc_name_p (const char *, unsigned int);
 %}

--- a/gcc/cp/cfns.h
+++ b/gcc/cp/cfns.h
@@ -52,7 +52,7 @@ __inline
 #endif
 static unsigned int hash (const char *, unsigned int);
 #ifdef __GNUC__
-//__inline
+__inline
 #endif
 const char * libc_name_p (const char *, unsigned int);
 /* maximum key range = 391, duplicates = 0 */


### PR DESCRIPTION
ppe42 does not support byte swap instructions, so disable it for ppe42.