### PR TITLE
Backport fix for search_line_fast on POWER/ALTIVEC

### DIFF
--- a/libcpp/lex.c
+++ b/libcpp/lex.c
@@ -551,7 +551,7 @@ search_line_fast (const uchar *s, const uchar *end ATTRIBUTE_UNUSED)
     {
       vc m_nl, m_cr, m_bs, m_qm;
 
-      data = *((const vc *)s);
+      data = __builtin_vec_vsx_ld (0, s);
       s += 16;
 
       m_nl = (vc) __builtin_vec_cmpeq(data, repl_nl);


### PR DESCRIPTION
This patch (backported from upstream GCC) is required to fix a runtime issue preventing ppe42-gcc (when built on a Power host with a modern GCC toolchain) to build Power binaries.

 -Klaus